### PR TITLE
Include INSTALL.rst to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include README.rst
+include INSTALL.rst


### PR DESCRIPTION
So that reference link works properly in PyPI and the file is included with installation.