### PR TITLE
Fix _update_self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Documentation at http://docs.blackfynn.io
 
+## [2.1.3]
+### Changed
+- Updated `_update_self` to more reliably rely on model IDs for self verification
+
 ## [2.1.1]
 ### Changed
 - Fixed re-authentication by maintaining organization context

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-blackfynn-py
-============
+blackfynn-python
+================
 
 Python client and command line tool for Blackfynn.
 

--- a/blackfynn/__init__.py
+++ b/blackfynn/__init__.py
@@ -1,6 +1,6 @@
 
 __title__ = 'blackfynn'
-__version__ = '2.1.2'
+__version__ = '2.1.3'
 
 from .config import settings
 

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -40,11 +40,11 @@ def get_package_class(data):
 
     return p
 
-def update_self(self, new):
-    if type(self) != type(new):
-        raise Exception("cannot update a(n) {} using a(n) {}".format(type(self), type(new)))
+def _update_self(self, updated):
+    if self.id != updated.id:
+        raise Exception("cannot update {} with {}".format(self, updated))
 
-    self.__dict__.update(new.__dict__)
+    self.__dict__.update(updated.__dict__)
 
     return self
 
@@ -385,7 +385,7 @@ class BaseDataNode(BaseNode):
         """
         self._check_exists()
         r = self._api.core.update(self, **kwargs)
-        update_self(self, r)
+        _update_self(self, r)
 
     def delete(self):
         """


### PR DESCRIPTION
### Motivation
It's more reliable to compare models' `id` when calling `_update_self`.


### Functional Testing
```
In [1]: from blackfynn import Blackfynn

In [2]: bf = Blackfynn()

In [3]: d = bf.get_dataset('Blackfynn Dataset')

In [4]: from blackfynn.models import _update_self

In [5]: _update_self(d, d)

Out[5]: <Dataset name='Blackfynn Dataset' id='N:dataset:c0f0db41-c7cb-4fb5-98b4-e90791f8a975'>

In [6]: t = bf.create_dataset('Test Dataset')

In [7]: _update_self(d, t)
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-8-3b57780ccf57> in <module>()
----> 1 _update_self(d, t)

/Users/rohan/blackfynn/code/blackfynn-python/blackfynn/models.pyc in _update_self(self, updated)
     43 def _update_self(self, updated):
     44     if self.id != updated.id:
---> 45         raise Exception("cannot update {} with {}".format(self, updated))
     46
     47     self.__dict__.update(updated.__dict__)

Exception: cannot update <Dataset name='Blackfynn Dataset' id='N:dataset:c0f0db41-c7cb-4fb5-98b4-e90791f8a975'> with <Dataset name='Test Dataset' id='N:dataset:7f94b00e-c238-4cf4-bb7b-1eafe8074b5e'>
```