### PR TITLE
Track package owner

### DIFF
--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -667,6 +667,12 @@ class BaseCollection(BaseDataNode):
 
         return contains
 
+    def as_dict(self):
+        d = super(BaseCollection, self).as_dict()
+        if self.owner_id is not None:
+            d['owner'] = self.owner_id
+        return d
+    
     @classmethod
     def from_dict(cls, data, *args, **kwargs):
         item = super(BaseCollection, cls).from_dict(data, *args, **kwargs)

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -779,6 +779,12 @@ class DataPackage(BaseDataNode):
         self._check_exists()
         return self._api.packages.get_view(self)
 
+    def as_dict(self):
+        d = super(DataPackage, self).as_dict()
+        if self.owner_id is not None:
+            d['owner'] = self.owner_id
+        return d
+    
     @classmethod
     def from_dict(cls, data, *args, **kwargs):
         item = super(DataPackage, cls).from_dict(data, *args, **kwargs)


### PR DESCRIPTION
This PR adds the owner id to the dictionary for packages and collections.  This change allows the owner id to be passed to the Blackfynn API upon package/collection creation.