### PR TITLE
Remove deeply imported `settings`

### DIFF
--- a/blackfynn/api/base.py
+++ b/blackfynn/api/base.py
@@ -2,7 +2,6 @@
 import urllib
 
 # blackfynn
-from blackfynn import settings
 from blackfynn.models import get_package_class
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -10,7 +9,7 @@ from blackfynn.models import get_package_class
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 class APIBase(object):
-    host = settings.api_host
+    host = None
     base_uri = ''
     name = ''
 


### PR DESCRIPTION
Remove `settings` that were imported inappropriately. 

To consider: 
- remove `global` here as it seems to serve no purpose: https://github.com/Blackfynn/blackfynn-python/blob/master/blackfynn/client.py#L69
- refactor to remove the export of `settings` from https://github.com/Blackfynn/blackfynn-python/blob/master/blackfynn/config.py#L198 to prevent this kind of error from happening again. It seems pathological to use the singleton pattern here along with `use_profile` since that will require that you never try to access settings until `use_profile` has been called. More so, the singleton pattern is actually antithesis to the original intent of the structure of this package: one cannot actually instantiate and easily switch between different profiles because you're using a singleton that is shared among all profiles! 
```py
bf_og = Blackfynn()
bf_dev = Blackfynn("dev")
bf_og.datasets() # this will access all of bf_dev's datasets! 
```