### PR TITLE
Track package owner and file size

### DIFF
--- a/blackfynn/__init__.py
+++ b/blackfynn/__init__.py
@@ -1,6 +1,6 @@
 
 __title__ = 'blackfynn'
-__version__ = '2.1.3'
+__version__ = '2.1.4'
 
 from .config import settings
 

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -673,7 +673,7 @@ class BaseCollection(BaseDataNode):
         if self.owner_id is not None:
             d['owner'] = self.owner_id
         return d
-    
+
     @classmethod
     def from_dict(cls, data, *args, **kwargs):
         item = super(BaseCollection, cls).from_dict(data, *args, **kwargs)
@@ -786,6 +786,12 @@ class DataPackage(BaseDataNode):
         """
         self._check_exists()
         return self._api.packages.get_view(self)
+
+    def as_dict(self):
+        d = super(DataPackage, self).as_dict()
+        if self.owner_id is not None:
+            d['owner'] = self.owner_id
+        return d
 
     @classmethod
     def from_dict(cls, data, *args, **kwargs):

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -489,6 +489,7 @@ class BaseCollection(BaseDataNode):
         # items is None until an API response provides the item objects 
         # to be parsed, which then updates this instance.
         self._items = None
+        self.storage = kwargs.pop('storage', None)
 
     def add(self, *items):
         """
@@ -703,6 +704,7 @@ class DataPackage(BaseDataNode):
         super(DataPackage, self).__init__(name=name, type=package_type, **kwargs)
         # local-only attribute
         self.session = None
+        self.storage = kwargs.pop('storage', None)
 
     def set_view(self, *files):
         """
@@ -1687,6 +1689,7 @@ class User(BaseNode):
         self.authy_id = authy_id
         self.accepted_terms = ''
         self.is_super_admin = is_super_admin
+        self.storage = kwargs.pop('storage', None)
 
     def __repr__(self):
         return u"<User email=\'{}\' id=\'{}\'>".format(self.email, self.id)
@@ -1715,6 +1718,7 @@ class Organization(BaseNode):
         self.subscription_state = subscription_state
         self.encryption_key_id = encryption_key_id
         self.slug = name.lower().replace(' ','-') if slug is None else slug
+        self.storage = kwargs.pop('storage', None)
 
     @property
     def datasets(self):

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -787,12 +787,6 @@ class DataPackage(BaseDataNode):
         self._check_exists()
         return self._api.packages.get_view(self)
 
-    def as_dict(self):
-        d = super(DataPackage, self).as_dict()
-        if self.owner_id is not None:
-            d['owner'] = self.owner_id
-        return d
-    
     @classmethod
     def from_dict(cls, data, *args, **kwargs):
         item = super(DataPackage, cls).from_dict(data, *args, **kwargs)
@@ -828,6 +822,7 @@ class File(BaseDataNode):
         s3_key (str):    S3 key of file
         s3_bucket (str): S3 bucket of file
         file_type (str): Type of file, e.g. 'MPEG', 'PDF'
+        file_size (long): Size of file
 
     Note:
         ``file_type`` must be a supported file type. See our file type registry
@@ -837,12 +832,13 @@ class File(BaseDataNode):
     """
     _type_name = 'fileType'
 
-    def __init__(self, name, s3_key, s3_bucket, file_type, pkg_id=None, **kwargs):
+    def __init__(self, name, s3_key, s3_bucket, file_type, file_size, pkg_id=None, **kwargs):
         super(File, self).__init__(name, type=file_type, **kwargs)
 
         # data
         self.s3_key = s3_key
         self.s3_bucket = s3_bucket
+        self.file_size = file_size
         self.pkg_id = pkg_id
         self.local_path = None
 
@@ -850,7 +846,8 @@ class File(BaseDataNode):
         d = super(File, self).as_dict()
         d.update({
             "s3bucket": self.s3_bucket,
-            "s3key": self.s3_key
+            "s3key": self.s3_key,
+            "size": self.file_size
         })
         d.pop('parent', None)
         props = d.pop('properties')
@@ -901,8 +898,8 @@ class File(BaseDataNode):
         return f_local
 
     def __repr__(self):
-        return u"<File name='{}' type='{}' key='{}' bucket='{}' id='{}'>" \
-                    .format(self.name, self.type, self.s3_key, self.s3_bucket, self.id)
+        return u"<File name='{}' type='{}' key='{}' bucket='{}' size='{}' id='{}'>" \
+                    .format(self.name, self.type, self.s3_key, self.s3_bucket, self.file_size, self.id)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -668,6 +668,12 @@ class BaseCollection(BaseDataNode):
 
         return contains
 
+    def as_dict(self):
+        d = super(BaseCollection, self).as_dict()
+        if self.owner_id is not None:
+            d['owner'] = self.owner_id
+        return d
+    
     @classmethod
     def from_dict(cls, data, *args, **kwargs):
         item = super(BaseCollection, cls).from_dict(data, *args, **kwargs)
@@ -781,6 +787,12 @@ class DataPackage(BaseDataNode):
         self._check_exists()
         return self._api.packages.get_view(self)
 
+    def as_dict(self):
+        d = super(DataPackage, self).as_dict()
+        if self.owner_id is not None:
+            d['owner'] = self.owner_id
+        return d
+    
     @classmethod
     def from_dict(cls, data, *args, **kwargs):
         item = super(DataPackage, cls).from_dict(data, *args, **kwargs)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -207,9 +207,9 @@ def test_package_objects(client, superuser_client, dataset):
     assert not pkg.exists
 
     # some files (local for now)
-    source = File(name='My Source File', s3_key='s3/source', s3_bucket='my-bucket', file_type="JSON")
-    file   = File(name='My File', s3_key='s3/file', s3_bucket='my-bucket', file_type="CSV")
-    view   = File(name='My View File', s3_key='s3/view', s3_bucket='my-bucket', file_type="NIFTI")
+    source = File(name='My Source File', s3_key='s3/source', s3_bucket='my-bucket', file_type="JSON", file_size=1000)
+    file   = File(name='My File', s3_key='s3/file', s3_bucket='my-bucket', file_type="CSV", file_size=1000)
+    view   = File(name='My View File', s3_key='s3/view', s3_bucket='my-bucket', file_type="NIFTI", file_size=1000)
 
     # get dataset (but as super-user)
     superuser_dataset = superuser_client._api.datasets.get(dataset.id)


### PR DESCRIPTION
This PR makes the following updates to the Blackfynn Python client:

1.  Owner ID has been added to the dictionary for packages and collections. This change allows the owner id to be passed to the Blackfynn API upon package/collection creation.
2.  A field for "file size" has been added to the File class. The addition of this field allows the Blackfynn API to accurately calculate the size of a package, collection, dataset, etc.
3. The models for Package, Dataset, Collection, User, and Organization have been updated to handle the "storage" field that is now being included in API responses.