### PR TITLE
Bug fix: Retrieve chunk slice based on time index

### DIFF
--- a/blackfynn/api/timeseries.py
+++ b/blackfynn/api/timeseries.py
@@ -214,7 +214,7 @@ class ChannelIterator(object):
                 else:
                     # more pages needed - reset
                     page = None
-                data_slice = data.ix[i_start:i_stop]
+                data_slice = data.loc[i_start:i_stop]
                 if self.chunk_per_page:
                     yield data_slice
                 else:
@@ -230,16 +230,17 @@ class ChannelIterator(object):
 
     def _get_chunk(self):
         # get chunk data based on time
-        chunk_delta = self.channel._page_delta(self.chunk_size)-1
-        end = self.offset + datetime.timedelta(microseconds=chunk_delta)
+        chunk_delta = self.channel._page_delta(self.chunk_size)
+        end = self.offset + datetime.timedelta(microseconds=chunk_delta-1)
         chunk_data = self.chunk.loc[:end]
         # leave remainder
-        self.chunk = self.chunk.loc[end:]
-        self.offset = end
+        start = end + datetime.timedelta(microseconds=1)
+        self.chunk = self.chunk.loc[start:]
+        self.offset = start
         if len(chunk_data):
             return chunk_data
         # chunk is empty
-        if end >= self.stop_dt:
+        if start >= self.stop_dt:
             # terminate sequence
             return None
         else:

--- a/blackfynn/api/timeseries.py
+++ b/blackfynn/api/timeseries.py
@@ -237,12 +237,12 @@ class ChannelIterator(object):
         start = end + datetime.timedelta(microseconds=1)
         self.chunk = self.chunk.loc[start:]
         self.offset = start
-        if len(chunk_data):
-            return chunk_data
-        # chunk is empty
-        if start >= self.stop_dt:
+        if end >= self.stop_dt:
             # terminate sequence
             return None
+        elif len(chunk_data):
+            # valid data
+            return chunk_data
         else:
             # empty chunk
             return pd.Series([])

--- a/blackfynn/api/timeseries.py
+++ b/blackfynn/api/timeseries.py
@@ -229,6 +229,9 @@ class ChannelIterator(object):
             yield self._get_chunk()
 
     def _get_chunk(self):
+        if self.offset >= self.stop_dt:
+            # terminate sequence
+            return None
         # get chunk data based on time
         chunk_delta = self.channel._page_delta(self.chunk_size)
         end = self.offset + datetime.timedelta(microseconds=chunk_delta-1)
@@ -237,10 +240,7 @@ class ChannelIterator(object):
         start = end + datetime.timedelta(microseconds=1)
         self.chunk = self.chunk.loc[start:]
         self.offset = start
-        if end >= self.stop_dt:
-            # terminate sequence
-            return None
-        elif len(chunk_data):
+        if len(chunk_data):
             # valid data
             return chunk_data
         else:


### PR DESCRIPTION
When retrieving time series data in an iterative/chunked manner, e.g. using `.get_data_iter`, there is a possibility of incorrect chunk responses when gaps are present in the data. 

Note: this is a hot-fix for the retrieval mechanism in the existing client. In the near future, all time series requests are rerouted through the agent (pending release).