### PR TITLE
Setup Changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.4.4
-requests==2.13.0
+requests==2.18.3
 requests-futures==0.9.7
 numpy==1.13.1
 pandas==0.20.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import os
 import re
-from pip.download import PipSession
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
@@ -17,9 +15,8 @@ with open('blackfynn/__init__.py', 'r') as fd:
 if not version:
     raise RuntimeError('Cannot find version information')
 
-install_reqs = parse_requirements('requirements.txt', session=PipSession())
-reqs = [str(ir.req) for ir in install_reqs]
-
+with open('requirements.txt', 'r') as f:
+    reqs = [line.strip() for line in f if not line.startswith('#')]
 
 here = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ with open('blackfynn/__init__.py', 'r') as fd:
 if not version:
     raise RuntimeError('Cannot find version information')
 
-with open('requirements.txt', 'r') as f:
-    reqs = [line.strip() for line in f if not line.startswith('#')]
-
 here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'requirements.txt'), mode='r', encoding='utf-8') as f:
+    reqs = [line.strip() for line in f if not line.startswith('#')]
 
 # Get the long description from the README file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:


### PR DESCRIPTION
### Motivation
Using `parse_requirements` and `pip.download.PipSession` isn't compatible with newer version of `pip`. This takes a simpler approach to parsing the requirements file.