### PR TITLE
Adding new endpoint argument for completing uploads

### DIFF
--- a/blackfynn/api/transfers.py
+++ b/blackfynn/api/transfers.py
@@ -316,7 +316,7 @@ class IOAPI(APIBase):
                 import_id_map[files[index]] = import_id
         return import_id_map
 
-    def set_upload_complete(self, import_id, dataset_id, destination_id, append=False):
+    def set_upload_complete(self, import_id, dataset_id, destination_id, append=False, targets=None):
         params = dict(
             append = append,
             datasetId = dataset_id,
@@ -324,8 +324,9 @@ class IOAPI(APIBase):
         )
         if destination_id is not None:
             params['destinationId'] = destination_id
-
+        
         return self._post(
-            endpoint = self._uri('/files/upload/complete/{import_id}', import_id=import_id),
-            params = params,
+            endpoint=self._uri('/files/upload/complete/{import_id}', import_id=import_id),
+            params=params,
+            json = targets
             )


### PR DESCRIPTION
The endpoint to complete an upload was enhanced in the API to allow a file to be related to a resource in the graph in a single action. This feature is available in production and backwards compatible. The change in this pull request enhances the client to take advantage of the aforementioned API enhancement.