### PR TITLE
Revisit graph methods

### DIFF
--- a/blackfynn/__init__.py
+++ b/blackfynn/__init__.py
@@ -16,6 +16,7 @@ from .models import (
     DataPackage,
     Collection,
     Model,
+    ModelProperty,
     Record,
     RecordSet,
     Dataset,

--- a/blackfynn/api/concepts.py
+++ b/blackfynn/api/concepts.py
@@ -32,6 +32,7 @@ class ModelsAPIBase(APIBase):
         else:
             raise Exception("could not get relationship type from relationship {} or instance {} ".format(relationship, instance))
 
+
 class ModelsAPI(ModelsAPIBase):
     base_uri = "/datasets"
     name = 'concepts'
@@ -56,6 +57,15 @@ class ModelsAPI(ModelsAPIBase):
         dataset_id = self._get_id(dataset)
         resp = self._put(self._uri('/{dataset_id}/concepts/{id}/properties', dataset_id=dataset_id, id=concept.id), json=data)
         return [ModelProperty.from_dict(r) for r in resp]
+
+    def delete_property(self, dataset, concept, prop):
+        dataset_id  = self._get_id(dataset)
+        concept_id  = self._get_id(concept)
+        property_id = self._get_id(prop)
+        return self._del(self._uri('/{dataset_id}/concepts/{concept_id}/properties/{property_id}',
+                dataset_id  = dataset_id,
+                concept_id  = concept_id,
+                property_id = property_id))
 
     def get(self, dataset, concept):
         dataset_id = self._get_id(dataset)
@@ -121,7 +131,6 @@ class ModelsAPI(ModelsAPIBase):
                 instance_id=instance_id
             ))
         return [DataPackage.from_dict(pkg, api=self.session) for r,pkg in resp]
-
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/blackfynn/api/timeseries.py
+++ b/blackfynn/api/timeseries.py
@@ -487,8 +487,8 @@ class TimeSeriesAPI(APIBase):
                 channel = channel_id,
                 package = package_id,
                 session = self.session.token,
-                start   = self.start,
-                end     = self.stop
+                start   = start,
+                end     = stop
             )
         )
         return np.array(resp)

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2614,7 +2614,7 @@ class Model(BaseModelNode):
 
         Example::
 
-          mouse_002 = mouse.create({"id": 2, "weight": 2.2})
+          mouse_002 = mouse.create_record({"id": 2, "weight": 2.2})
 
         """
         self._check_exists()
@@ -2630,7 +2630,7 @@ class Model(BaseModelNode):
         ci = self._api.concepts.instances.create(self.dataset_id, ci)
         return ci
 
-    def create_records(self, *values_list):
+    def create_records(self, values_list):
         """
         Creates multiple records of the model on the platform.
 
@@ -2639,6 +2639,17 @@ class Model(BaseModelNode):
 
         Returns:
             Array of newly created ``Record``s.
+
+        Example::
+
+            mouse.create_records([
+                { 'id': 311, 'weight': 1.9 },
+                { 'id': 312, 'weight': 2.1 },
+                { 'id': 313, 'weight': 1.8 },
+                { 'id': 314, 'weight': 2.3 },
+                { 'id': 315, 'weight': 2.0 }
+            ])
+
         """
         self._check_exists()
         schema_keys = set(self.schema.keys())
@@ -2670,7 +2681,7 @@ class Model(BaseModelNode):
 
     def delete_records(self, *records):
         """
-        Deletes multiple records of a concept from the platform.
+        Deletes one or more records of a concept from the platform.
 
         Args:
             *records: instances and/or ids of records to delete
@@ -2756,7 +2767,7 @@ class Record(BaseRecord):
             return self._api.concepts.instances.get_all_related_of_type(self.dataset_id, self, model)
 
 
-    def files(self):
+    def get_files(self):
         """
         All files related to the current record.
 
@@ -2764,7 +2775,8 @@ class Record(BaseRecord):
             List of data objects i.e. ``DataPackage``
 
         Example::
-            eegs = mouse_001.files()
+            mouse_001.get_files()
+
         """
         return self._api.concepts.files(self.dataset_id, self.type, self)
 
@@ -2798,7 +2810,12 @@ class Record(BaseRecord):
         # accept object or list
         if isinstance(destinations, (Record, DataPackage)):
             destinations = [destinations]
+        if isinstance(destinations, (Collection,)):
+            destinations = destinations.items
 
+        if not destinations:
+            return None
+            
         # default values
         if values is None:
             values = [dict() for _ in destinations] if values is None else values

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2284,16 +2284,33 @@ class BaseModelNode(BaseNode):
     def add_properties(self, properties):
         """
         Appends multiple properties to the object's schema and updates the object
-        on the platform. Individual properties in the list can be specified in
-        multiple ways; as ``tuples``, ``dicts``, or just as the name of the
-        property for any properties that are simply strings.
+        on the platform. 
 
         Args:
           properties (list): List of properties to add
 
         Example::
 
-            mouse.add_properties([('weight', float), {'name': 'id', 'data_type': long}, 'description'])
+            Add properties using ``ModelProperty`` objects::
+
+                model.add_properties([
+                    ModelProperty('name', data_type=str, title=True),
+                    ModelProperty('age',  data_type=int)
+                ])
+
+            Add properties defined as list of dictionaries::
+
+                model.add_properties([
+                        {
+                            'name': 'full_name',
+                            'type': str, 
+                            'title': True
+                        },
+                        {
+                            'name': 'age',
+                            'type': int,
+                        }
+                ])
         """
         self._add_properties(properties)
 

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2289,6 +2289,10 @@ class BaseModelNode(BaseNode):
         Args:
           properties (list): List of properties to add
 
+        Note:
+            At least one property on a model needs to serve as the model's title.
+            See ``title`` argument in example(s) below.
+
         Example::
 
             Add properties using ``ModelProperty`` objects::

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2333,7 +2333,7 @@ class BaseModelNode(BaseNode):
             At least one property on a model needs to serve as the model's title.
             See ``title`` argument in example(s) below.
 
-        Example::
+        Example:
 
             Add properties using ``ModelProperty`` objects::
 

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -1952,6 +1952,8 @@ class Dataset(BaseCollection):
             
             Create a participant model, including schema::
 
+                from blackfynn import ModelProperty
+
                 ds.create_model('participant',
                     description = 'a human participant in a research study',
                     schema = [

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2689,7 +2689,7 @@ class Record(BaseRecord):
         if isinstance(destinations[0], DataPackage):
             # if linking packages, link one at a time
             result = [
-                self._api.relationships.instances.links(self.dataset_id, relationship_type, self, d, values=v)
+                self._api.concepts.relationships.instances.link(self.dataset_id, relationship_type, self, d, values=v)
                 for d,v in zip(destinations, values)
             ]
             return RelationshipSet(relationship_type, result)


### PR DESCRIPTION
### NEW:
- Added `model.remove_property(...)` method
- Added Record API endpoints for 
  - `get_all_related`
  - `get_all_related_of_type`
  - `get_counts`

### REMOVED:
The following methods caused confusion, and generally, wanted to have graph methods be more record-oriented, and avoid treating relationships as objects.
- `record.neighbors()`
- `record.links()`
- `record.relationships()`

( see `record.get_related()` which accomplish above)

### CHANGES:
- `record.link(...)` is now `record.relate_to(...)`
- Use `record.get_related()` to get any related records
   - Removed `record.neighbors()`, `record.links()`, and `record.relationships()` as they caused confusion, and generally focused on being more record-oriented, and avoided treating relationships as objects.
- `record.files` is now `record.get_files()`
- `dataset.create_relationship(...)` is now `dataset.create_relationship_type(...)`
- `model.create_records(v1, v2, ...)` is now `model.create_records([v1, v2, ...])` (not using `*args` format).
- `relationship_type. create_many(...)` is now `relationship_type.create(...)`
- Updated/added to docstrings for better documentation.
