### PR TITLE
APP-943: Fix Annotation Counts Functions

### DIFF
--- a/blackfynn/api/timeseries.py
+++ b/blackfynn/api/timeseries.py
@@ -736,10 +736,25 @@ class TimeSeriesAPI(APIBase):
 
     def query_annotation_counts(self, ts, layers, start, end, period, channels=None, merge_periods=False):
         """
-        Retrives annotation counts for a given ts, channel, start, end, and/or layer
+        Retrieves annotation counts for a given ts, channel, start, end, and/or layer
+
+        Args:
+            ts (TimeSeries)                  : The timeseries package for which to count annotations
+            layers ([TimeSeriesLayer])       : List of layers for which to count annotations
+            start (datetime or microseconds) : The starting time of the range to query
+            end (datetime or microseconds)   : The ending time of the the range to query
+            period (string)                  : The length of time to group the counts.
+                                               Formatted as a string - e.g. '1s', '5m', '3h'
+            channels ([TimeSeriesChannel])   : List of channel (if omitted, all channels will be used)
+            merge_periods(Boolean)           : If true, merge consecutive result periods together to
+                                               reduce the size of the resulting payload
+
+        Returns:
+            A dict
+            layer_id -> list of counts for each period
         """
         if channels is None:
-            ch_list = [] #empty uses all channels
+            ch_list = [] # empty uses all channels
         else:
             ch_list = [self._get_id(x) for x in channels]
 

--- a/blackfynn/api/timeseries.py
+++ b/blackfynn/api/timeseries.py
@@ -734,7 +734,7 @@ class TimeSeriesAPI(APIBase):
 
         return [TimeSeriesAnnotation.from_dict(x, api=self.session) for x in resp['annotations']['results']]
 
-    def annotation_counts(self, ts, layer, start, end, period, channels=None):
+    def query_annotation_counts(self, ts, layers, start, end, period, channels=None, merge_periods=False):
         """
         Retrives annotation counts for a given ts, channel, start, end, and/or layer
         """
@@ -751,14 +751,16 @@ class TimeSeriesAPI(APIBase):
         period = parse_timedelta(period)
 
         params = {
+            'aggregation': 'count',
             'start': long(start),
             'end': long(end),
-            'channelIds': ch_list,
-            'period': period,
-            'layer': layer.name
+            'period': long(period),
+            'mergePeriods': merge_periods,
+            'layerIds': [l.id for l in layers],
+            'channelIds': ch_list
         }
 
-        path = self._uri('/{ts_id}/annotations',
+        path = self._uri('/{ts_id}/annotations/window',
                     ts_id = self._get_id(ts))
 
         resp = self._get(path, params=params)

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -1291,10 +1291,12 @@ class TimeSeries(DataPackage):
         Get annotation counts between ``start`` and ``end``.
 
         Args:
-            channels: list of channels to query over
-            start: start time of query (datetime object or usecs from Epoch)
-            end: end time of query (datetime object or usecs from Epoch)
-
+            start (datetime or microseconds) : The starting time of the range to query
+            end (datetime or microseconds)   : The ending time of the the range to query
+            layers ([TimeSeriesLayer])       : List of layers for which to count annotations
+            period (string)                  : The length of time to group the counts.
+                                               Formatted as a string - e.g. '1s', '5m', '3h'
+            channels ([TimeSeriesChannel])   : List of channel (if omitted, all channels will be used)
         """
         self._check_exists()
         return self._api.timeseries.query_annotation_counts(
@@ -1570,9 +1572,11 @@ class TimeSeriesAnnotationLayer(BaseNode):
         channels (all by default).
 
         Args:
-            start:    Start time
-            end:      End time
-            channels: List of channel objects or IDs
+            start (datetime or microseconds) : The starting time of the range to query
+            end (datetime or microseconds)   : The ending time of the the range to query
+            period (string)                  : The length of time to group the counts.
+                                               Formatted as a string - e.g. '1s', '5m', '3h'
+            channels ([TimeSeriesChannel])   : List of channel (if omitted, all channels will be used)
         """
         self._check_exists()
         ts = self._api.core.get(self.time_series_id)

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -1286,7 +1286,7 @@ class TimeSeries(DataPackage):
         self._check_exists()
         return self._api.timeseries.delete_annotation_layer(layer)
 
-    def query_annotation_counts(self, channels, start, end, layer=None):
+    def annotation_counts(self, start, end, layers, period, channels=None):
         """
         Get annotation counts between ``start`` and ``end``.
 
@@ -1298,7 +1298,9 @@ class TimeSeries(DataPackage):
         """
         self._check_exists()
         return self._api.timeseries.query_annotation_counts(
-            channels=channels,start=start,end=end,layer=layer)
+            ts=self, layers=layers, channels=channels, start=start, end=end,
+            period=period
+        )
 
     def __repr__(self):
         return u"<TimeSeries name=\'{}\' id=\'{}\'>".format(self.name, self.id)
@@ -1559,9 +1561,10 @@ class TimeSeriesAnnotationLayer(BaseNode):
         self._check_exists()
         ts = self._api.core.get(self.time_series_id)
         return self._api.timeseries.query_annotations(
-            ts=ts, layer=self, channels=channels, start=start, end=end)
+            ts=ts, layer=self, channels=channels, start=start, end=end
+        )
 
-    def annotation_counts(self, start, end, channels=None):
+    def annotation_counts(self, start, end, period, channels=None):
         """
         The number of annotations between ``start`` and ``end`` over selected
         channels (all by default).
@@ -1574,7 +1577,8 @@ class TimeSeriesAnnotationLayer(BaseNode):
         self._check_exists()
         ts = self._api.core.get(self.time_series_id)
         return self._api.timeseries.query_annotation_counts(
-            ts=ts, layer=self, channels=channels, start=start, end=end)
+            ts=ts, layers=[self], channels=channels, start=start, end=end, period=period
+        )
 
     def delete(self):
         """

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -3,6 +3,7 @@ import pdb
 from blackfynn import TimeSeries, TimeSeriesChannel
 from blackfynn.models import TimeSeriesAnnotationLayer, TimeSeriesAnnotation
 import datetime
+
 @pytest.fixture()
 def timeseries(client, dataset):
     # create
@@ -205,6 +206,32 @@ def test_timeseries_annotations(client, timeseries):
     next_annot= annot_gen.next()
     assert next_annot[0].label == 'test_label2'
 
+    ### TEST ANNOTATION COUNTS
+    layer1_expected_counts = [
+        {'start': 0, 'end': 250000, 'value': 1.0},
+        {'start': 250000, 'end': 500000, 'value': 1.0},
+        {'start': 500000, 'end': 750000, 'value': 1.0},
+        {'start': 750000, 'end': 1000000, 'value': 1.0},
+        {'start': 1000000, 'end': 1250000, 'value': 2.0},
+        {'start': 1250000, 'end': 1500000, 'value': 1.0},
+        {'start': 1500000, 'end': 1750000, 'value': 1.0},
+        {'start': 1750000, 'end': 2000000, 'value': 1.0},
+        {'start': 2000000, 'end': 2000001, 'value': 1.0}
+    ]
+    assert sorted(
+        timeseries.annotation_counts(
+            start = timeseries.channels[0].start * 1e6,
+            end = timeseries.channels[0].start + 2 * 1e6,
+            layers=[layer1], period="0.25s"
+        )[str(layer1.id)]
+    ) == layer1_expected_counts
+    assert sorted(
+        layer1.annotation_counts(
+            start = timeseries.channels[0].start * 1e6,
+            end = timeseries.channels[0].start + 2 * 1e6,
+            period="0.25s"
+        )[str(layer1.id)]
+    ) == layer1_expected_counts
 
     ### TEST DELETION
 


### PR DESCRIPTION
Annotations counts functions were both misnamed and were using the wrong API endpoint