### PR TITLE
Add smart dataframes

### DIFF
--- a/blackfynn/api/concepts.py
+++ b/blackfynn/api/concepts.py
@@ -158,7 +158,14 @@ class ModelsAPI(ModelsAPIBase):
                 concept_id=concept_id,
                 instance_id=instance_id
             ))
-        return [DataPackage.from_dict(pkg, api=self.session) for r,pkg in resp]
+
+        # TODO: AE-393 fix this in the concept service
+        try:
+            return [DataPackage.from_dict(pkg, api=self.session) for r,pkg in resp]
+        except ValueError:
+            if isinstance(resp, string_types):
+                return []
+            raise
 
     def get_related(self, dataset, concept):
         dataset_id = self._get_id(dataset)

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -3661,7 +3661,7 @@ class GraphView(BaseRecord):
         model_names = [self.root_model] + self.included_models
         return {name: self.dataset.get_model(name) for name in model_names}
 
-    def as_dataframe(self, columns=None, full_models=True):
+    def as_dataframe(self, columns=None, full_records=True):
         """
         Returns:
             pd.DataFrame:
@@ -3693,7 +3693,7 @@ class GraphView(BaseRecord):
             except:
                 pass
 
-        if full_models:
+        if full_records:
             df = self._embed_records_in_dataframe(df)
 
         return df

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -3672,7 +3672,6 @@ class GraphView(BaseRecord):
                 self._check_response(f.read())
             raise
 
-        df.columns = df.columns.astype(str)
         return df
 
     def as_json(self):

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -60,7 +60,6 @@ def get_package_class(data):
 
     return p
 
-
 def _update_self(self, updated):
     if self.id != updated.id:
         raise Exception("cannot update {} with {}".format(self, updated))
@@ -2405,11 +2404,8 @@ class BaseModelProperty(object):
         title = data.get('title', data.get('conceptTitle', False))
         id = data.get('id', None)
         required = data.get('required', False)
-        description = data.get("description", "")
 
-        return cls(name=data['name'], display_name=display_name,
-                   data_type=data_type, id=id, locked=locked, default=default,
-                   title=title, required=required, description=description)
+        return cls(name=data['name'], display_name=display_name, data_type=data_type, id=id, locked=locked, default=default, title=title, required=required)
 
     def as_dict(self):
         return dict(
@@ -2513,12 +2509,9 @@ class BaseModelNode(BaseNode):
 
         self._add_properties(schema)
 
-    def _add_property(self, name, display_name=None, data_type=str, title=False, description=""):
-        prop = self._property_cls(name=name, display_name=display_name,
-                                  data_type=data_type, title=title,
-                                  description=description)
+    def _add_property(self, name, display_name=None, data_type=str, title=False):
+        prop = self._property_cls(name=name, display_name=display_name, data_type=data_type, title=title)
         self.schema[prop.name] = prop
-        return prop
 
     def _add_properties(self, properties):
         if isinstance(properties, list):
@@ -2551,7 +2544,7 @@ class BaseModelNode(BaseNode):
     def update(self):
         pass
 
-    def add_property(self, name, data_type=str, display_name=None, title=False, description=""):
+    def add_property(self, name, data_type=str, display_name=None, title=False):
         """
         Appends a property to the object's schema and updates the object on the platform.
 
@@ -2559,8 +2552,6 @@ class BaseModelNode(BaseNode):
           name (str): Name of the property
           data_type (type, optional): Python type of the property. Defaults to ``string_types``.
           display_name (str, optional): Display name for the property.
-          title (bool, optional): If True, the property will be used in the title on the platform
-          description (str, optional): Description of the property
 
         Example:
           Adding a new property with the default data_type::
@@ -2569,11 +2560,12 @@ class BaseModelNode(BaseNode):
           Adding a new property with the ``float`` data_type::
             mouse.add_property('weight', float)
         """
-        prop = self._add_property(name, data_type=data_type,
-                                  display_name=display_name, title=title,
-                                  description=description)
-        self.update()
-        return prop
+        self._add_property(name, data_type=data_type, display_name=display_name, title=title)
+
+        try:
+            self.update()
+        except:
+            raise #Exception("local object updated, but failed to update remotely")
 
     def add_properties(self, properties):
         """
@@ -2611,7 +2603,11 @@ class BaseModelNode(BaseNode):
                 ])
         """
         self._add_properties(properties)
-        self.update()
+
+        try:
+            self.update()
+        except:
+            raise Exception("local object updated, but failed to update remotely")
 
     def remove_property(self, property):
         """

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,8 @@
 import uuid
 import pytest
 
-from blackfynn.models import Record
+from blackfynn import models
+
 
 
 # This must be a module level fixture because views with duplicate
@@ -82,9 +83,16 @@ def test_as_dataframe(graph_view, simple_graph):
     patient_model, medication_model = simple_graph.models
 
     assert set(df.columns) == set(['patient', 'patient.name', 'medication', 'medication.name'])
+    assert all([isinstance(r, models._LazyRecord) for r in df['patient']])
+    assert all([isinstance(r, models._LazyRecord) or r is None for r in df['medication']])
 
-    assert all([isinstance(r, Record) for r in df['patient']])
-    assert all([isinstance(r, Record) or r is None for r in df['medication']])
+
+def test_lazy_record(simple_graph):
+    patient = simple_graph.model_records[0]
+    lazy_patient = models._LazyRecord(patient.model, patient.id)
+    assert lazy_patient == patient
+    assert lazy_patient.get_files() == []
+    assert lazy_patient.get_related() == [simple_graph.model_records[2]]
 
 
 def test_as_json(graph_view):

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -86,7 +86,6 @@ def test_as_dataframe(graph_view, simple_graph):
     assert all([isinstance(r, Record) for r in df['patient']])
     assert all([isinstance(r, Record) or r is None for r in df['medication']])
 
-    import pdb; pdb.set_trace()
 
 def test_as_json(graph_view):
     json = graph_view.as_json()

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,6 +1,8 @@
 import uuid
 import pytest
 
+from blackfynn.models import Record
+
 
 # This must be a module level fixture because views with duplicate
 # root/included models are not allowed.
@@ -75,10 +77,16 @@ def test_cant_create_duplicate_views(graph_view):
         dataset.create_view('different-name-same-models', graph_view.root_model, graph_view.included_models)
 
 
-def test_as_dataframe(graph_view):
+def test_as_dataframe(graph_view, simple_graph):
     df = graph_view.as_dataframe()
+    patient_model, medication_model = simple_graph.models
+
     assert set(df.columns) == set(['patient', 'patient.name', 'medication', 'medication.name'])
 
+    assert all([isinstance(r, Record) for r in df['patient']])
+    assert all([isinstance(r, Record) or r is None for r in df['medication']])
+
+    import pdb; pdb.set_trace()
 
 def test_as_json(graph_view):
     json = graph_view.as_json()

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -77,11 +77,12 @@ def test_models(dataset):
     assert dataset.get_model(new_model.id) == new_model
     assert dataset.get_model(new_model.type) == new_model
 
-    # Check that local changes get propagated
     new_model.add_property('a_new_property', str, display_name)
     new_model.description = description
     new_model.update()
+
     new_model = dataset.get_model(new_model.id)
+
     assert new_model.description == description
     assert new_model.get_property('a_new_property').display_name == display_name
 
@@ -170,6 +171,7 @@ def test_models(dataset):
     nr_three = nc_three.relate_to(nc_four, new_relationship)
     nr_six = nc_four.relate_to(nc_three, new_relationship)
 
+    nc_four.update()
     assert len(nc_four.get_related(new_model.type)) == 4
 
     new_relationships = new_relationship.get_all()
@@ -191,6 +193,7 @@ def test_models(dataset):
     nc_three.relate_to(p, new_relationship)
     new_relationship.relate(nc_four, p)
 
+    nc_four.update()
     assert len(nc_four.get_related(new_model.type)) == 4
 
 def test_simple_model_properties(dataset):
@@ -201,14 +204,13 @@ def test_simple_model_properties(dataset):
 
      assert dataset.get_model(model_with_basic_props_1.id) == model_with_basic_props_1
 
-     # Add a property with a description
-     model_with_basic_props_1.add_property('a_new_property', float, display_name='Weight', description="some metric")
+     # Add a property
+     model_with_basic_props_1.add_property('a_new_property', float, display_name='Weight')
+     model_with_basic_props_1.update()
 
      updated_model_1 = dataset.get_model(model_with_basic_props_1.id)
 
-     test_prop = updated_model_1.get_property('a_new_property')
-     assert test_prop.display_name == 'Weight'
-     assert test_prop.description == "some metric"
+     assert updated_model_1.get_property('a_new_property').display_name == 'Weight'
 
      # Define properties as ModelProperty objects
      model_with_basic_props_2 = dataset.create_model('Basic_Props_2', description='a new description', schema=[
@@ -221,6 +223,7 @@ def test_simple_model_properties(dataset):
 
      # Add a property
      model_with_basic_props_2.add_property('weight2', ModelPropertyType(data_type=float), display_name='Weight')
+     model_with_basic_props_2.update()
 
      updated_model_2 = dataset.get_model(model_with_basic_props_2.id)
 
@@ -238,6 +241,7 @@ def test_simple_model_properties(dataset):
 
      # Add a property
      model_with_basic_props_3.add_property('weight3', ModelPropertyType(data_type=float), display_name='Weight')
+     model_with_basic_props_3.update()
 
      updated_model_3 = dataset.get_model(model_with_basic_props_3.id)
 
@@ -254,6 +258,7 @@ def test_simple_model_properties(dataset):
 
      # Add a property
      model_with_basic_props_4.add_property('weight4', ModelPropertyType(data_type='double'), display_name='Weight')
+     model_with_basic_props_4.update()
 
      updated_model_4 = dataset.get_model(model_with_basic_props_4.id)
 
@@ -271,6 +276,7 @@ def test_complex_model_properties(dataset):
 
     # Add a property
     model_with_complex_props.add_property('weight', ModelPropertyType(data_type=float, unit='kg'), display_name='Weight')
+    model_with_complex_props.update()
 
     updated_model = dataset.get_model(model_with_complex_props.id)
 

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -12,7 +12,7 @@ from blackfynn.models import (
     convert_type_to_datatype,
     uncast_value
 )
-from tests.utils import create_test_dataset, current_ts, get_test_client
+from tests.utils import create_test_dataset, current_ts, get_test_client, FILE1
 
 
 @pytest.mark.parametrize('fromtype,datatype,totype', [
@@ -335,3 +335,17 @@ def test_get_topology(simple_graph):
     assert len(topology['models']) == 2
     assert 'relationships' in topology
     assert len(topology['relationships']) == 1
+
+
+def test_get_files_related_to_record(simple_graph):
+    patient = simple_graph.model_records[0]
+    assert patient.get_files() == []
+
+    # TODO: remove response parsing once upload returns a DataPackage
+    resp = simple_graph.dataset.upload(FILE1)
+    package_id = resp[0][0]['package']['content']['id']
+    package = simple_graph.dataset.items[0]
+    assert package.id == package_id
+
+    patient.relate_to(package)
+    assert package in patient.get_files()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,17 +1,7 @@
-import os
-
 import pytest
 
-from pkg_resources import resource_filename
-
 from blackfynn.models import DataPackage, TimeSeries
-
-
-def _resource_path(fname):
-    return resource_filename('tests.resources', fname)
-
-FILE1 = _resource_path('test-upload.txt')
-FILE2 = _resource_path('test-upload-2.txt')
+from .utils import FILE1, FILE2
 
 
 @pytest.mark.parametrize('upload_args,n_files', [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,16 @@
 
 import time
 
+from pkg_resources import resource_filename
+
 from blackfynn import Blackfynn
+
+
+def _resource_path(fname):
+    return resource_filename('tests.resources', fname)
+
+FILE1 = _resource_path('test-upload.txt')
+FILE2 = _resource_path('test-upload-2.txt')
 
 
 def current_ts():


### PR DESCRIPTION
# Description

First pass at implementing basic smart dataframe functionality.

For each ID in the "pure" model columns, the code goes through and loads the corresponding `Record` object.

This can be pretty inefficient since it retrieves every record for every model, regardless of whether it is included, because there is currently no way to specify a subset of record objects to the service.

## Jira Issue

https://blackfynn.atlassian.net/browse/DS-554


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works