### PR TITLE
SHIELD-851: passing the ids of the concepts when creating many instan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Documentation at https://developer.blackfynn.io/python/
 
+## [2.11.1]
+### Changed
+- Using relate_to on concepts now populates the source and destination of the relationship
+
 ## [2.11.0]
 ### Changed
 - Knowledge graph query results now include the records of models specified

--- a/blackfynn/__init__.py
+++ b/blackfynn/__init__.py
@@ -31,4 +31,4 @@ from .models import (
 )
 
 __title__ = 'blackfynn'
-__version__ = '2.11.0'
+__version__ = '2.11.1'

--- a/blackfynn/api/concepts.py
+++ b/blackfynn/api/concepts.py
@@ -379,14 +379,10 @@ class ModelRelationshipsAPI(ModelsAPIBase):
         self.instances = ModelRelationshipInstancesAPI(session)
         super(ModelRelationshipsAPI, self).__init__(session)
 
-    def create(self, dataset, relationship, source=None, destination=None):
+    def create(self, dataset, relationship):
         assert isinstance(relationship, RelationshipType), "Must be of type Relationship"
         dataset_id = self._get_id(dataset)
         rel_dict = relationship.as_dict()
-        if source != None:
-            rel_dict['from'] = source
-        if destination != None:
-            rel_dict['to'] = destination
         r = self._post(self._uri('/{dataset_id}/relationships', dataset_id=dataset_id), json=rel_dict)
         r['dataset_id'] = r.get('dataset_id', dataset_id)
         return RelationshipType.from_dict(r, api=self.session)

--- a/blackfynn/api/concepts.py
+++ b/blackfynn/api/concepts.py
@@ -379,10 +379,15 @@ class ModelRelationshipsAPI(ModelsAPIBase):
         self.instances = ModelRelationshipInstancesAPI(session)
         super(ModelRelationshipsAPI, self).__init__(session)
 
-    def create(self, dataset, relationship):
+    def create(self, dataset, relationship, source=None, destination=None):
         assert isinstance(relationship, RelationshipType), "Must be of type Relationship"
         dataset_id = self._get_id(dataset)
-        r = self._post(self._uri('/{dataset_id}/relationships', dataset_id=dataset_id), json=relationship.as_dict())
+        rel_dict=relationship.as_dict()
+        if source != None:
+            rel_dict['from']=source
+        if destination !=None:
+            rel_dict['to']=destination
+        r = self._post(self._uri('/{dataset_id}/relationships', dataset_id=dataset_id), json=rel_dict)
         r['dataset_id'] = r.get('dataset_id', dataset_id)
         return RelationshipType.from_dict(r, api=self.session)
 

--- a/blackfynn/api/concepts.py
+++ b/blackfynn/api/concepts.py
@@ -379,13 +379,13 @@ class ModelRelationshipsAPI(ModelsAPIBase):
         self.instances = ModelRelationshipInstancesAPI(session)
         super(ModelRelationshipsAPI, self).__init__(session)
 
-    def create(self, dataset, relationship, source, destination):
+    def create(self, dataset, relationship, source=None, destination=None):
         assert isinstance(relationship, RelationshipType), "Must be of type Relationship"
         dataset_id = self._get_id(dataset)
         rel_dict = relationship.as_dict()
         if source != None:
             rel_dict['from'] = source
-        if destination !=None:
+        if destination != None:
             rel_dict['to'] = destination
         r = self._post(self._uri('/{dataset_id}/relationships', dataset_id=dataset_id), json=rel_dict)
         r['dataset_id'] = r.get('dataset_id', dataset_id)

--- a/blackfynn/api/concepts.py
+++ b/blackfynn/api/concepts.py
@@ -379,14 +379,14 @@ class ModelRelationshipsAPI(ModelsAPIBase):
         self.instances = ModelRelationshipInstancesAPI(session)
         super(ModelRelationshipsAPI, self).__init__(session)
 
-    def create(self, dataset, relationship, source=None, destination=None):
+    def create(self, dataset, relationship, source, destination):
         assert isinstance(relationship, RelationshipType), "Must be of type Relationship"
         dataset_id = self._get_id(dataset)
-        rel_dict=relationship.as_dict()
+        rel_dict = relationship.as_dict()
         if source != None:
-            rel_dict['from']=source
+            rel_dict['from'] = source
         if destination !=None:
-            rel_dict['to']=destination
+            rel_dict['to'] = destination
         r = self._post(self._uri('/{dataset_id}/relationships', dataset_id=dataset_id), json=rel_dict)
         r['dataset_id'] = r.get('dataset_id', dataset_id)
         return RelationshipType.from_dict(r, api=self.session)

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2131,9 +2131,11 @@ class Dataset(BaseCollection):
                 dataset_id  = self.id,
                 name        = name,
                 description = description,
+                source      = source,
+                destination = destination,
                 schema      = schema,
                 **kwargs)
-        return self._api.concepts.relationships.create(self.id, r, source, destination)
+        return self._api.concepts.relationships.create(self.id, r)
 
     def import_model(self, template):
         """
@@ -3250,8 +3252,8 @@ class Record(BaseRecord):
         if isinstance(relationship_type, string_types):
             relationships_types = self._api.concepts.relationships.get_all(self.dataset_id)
             if relationship_type not in relationships_types:
-                r = RelationshipType(dataset_id=self.dataset_id, name=relationship_type, description=relationship_type)
-                relationship_type = self._api.concepts.relationships.create(self.dataset_id, r, source=self.model.id, destination=destinations[0].model.id)
+                r = RelationshipType(dataset_id=self.dataset_id, name=relationship_type, description=relationship_type,  source=self.model.id, destination=destinations[0].model.id)
+                relationship_type = self._api.concepts.relationships.create(self.dataset_id, r)
             else:
                 relationship_type = relationships_types[relationship_type]
 
@@ -3430,8 +3432,8 @@ class RelationshipType(BaseModelNode):
 
     def __init__(self, dataset_id, name, display_name=None, description=None, locked=False, source=None, destination=None, *args, **kwargs): 
         kwargs.pop('type', None)
-        self.destination=destination
-        self.source=source
+        self.destination = destination
+        self.source = source
         super(RelationshipType, self).__init__(dataset_id, name, display_name, description, locked, *args, **kwargs)
 
     def update(self):
@@ -3588,7 +3590,10 @@ class RelationshipType(BaseModelNode):
     def as_dict(self):
         d = super(RelationshipType, self).as_dict()
         d['type'] = 'relationship'
-
+        if self.source != None:
+            d['from'] = self.source
+        if self.destination != None:
+            d['to'] = self.destination
         return d
 
     @as_native_str()

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -3428,9 +3428,10 @@ class RelationshipType(BaseModelNode):
     _object_key = ''
     _property_cls = RelationshipProperty
 
-    def __init__(self, dataset_id, name, display_name=None, description=None, locked=False, *args, **kwargs):
-
+    def __init__(self, dataset_id, name, display_name=None, description=None, locked=False, source=None, destination=None, *args, **kwargs): 
         kwargs.pop('type', None)
+        self.destination=destination
+        self.source=source
         super(RelationshipType, self).__init__(dataset_id, name, display_name, description, locked, *args, **kwargs)
 
     def update(self):

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2111,7 +2111,7 @@ class Dataset(BaseCollection):
             **kwargs)
         return self._api.concepts.create(self.id, c)
 
-    def create_relationship_type(self, name, description, schema=None, **kwargs):
+    def create_relationship_type(self, name, description, schema=None, source=None, destination=None, **kwargs):
         """
         Defines a ``RelationshipType`` on the platform.
 
@@ -2133,7 +2133,7 @@ class Dataset(BaseCollection):
                 description = description,
                 schema      = schema,
                 **kwargs)
-        return self._api.concepts.relationships.create(self.id, r)
+        return self._api.concepts.relationships.create(self.id, r, source, destination)
 
     def import_model(self, template):
         """
@@ -3251,7 +3251,7 @@ class Record(BaseRecord):
             relationships_types = self._api.concepts.relationships.get_all(self.dataset_id)
             if relationship_type not in relationships_types:
                 r = RelationshipType(dataset_id=self.dataset_id, name=relationship_type, description=relationship_type)
-                relationship_type = self._api.concepts.relationships.create(self.dataset_id, r,source=self.model.id, destination=destinations[0].model.id)
+                relationship_type = self._api.concepts.relationships.create(self.dataset_id, r, source=self.model.id, destination=destinations[0].model.id)
             else:
                 relationship_type = relationships_types[relationship_type]
 

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -3251,7 +3251,7 @@ class Record(BaseRecord):
             relationships_types = self._api.concepts.relationships.get_all(self.dataset_id)
             if relationship_type not in relationships_types:
                 r = RelationshipType(dataset_id=self.dataset_id, name=relationship_type, description=relationship_type)
-                relationship_type = self._api.concepts.relationships.create(self.dataset_id, r)
+                relationship_type = self._api.concepts.relationships.create(self.dataset_id, r,source=self.model.id, destination=destinations[0].model.id)
             else:
                 relationship_type = relationships_types[relationship_type]
 

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -170,10 +170,16 @@ def test_models(dataset):
     nr_two = nc_two.relate_to(nc_three, new_relationship)
     nr_three = nc_three.relate_to(nc_four, new_relationship)
     nr_six = nc_four.relate_to(nc_three, new_relationship)
+    nr_seven = nc_four.relate_to(nc_one, relationship_type="goes_to")
 
-    assert len(nc_four.get_related(new_model.type)) == 4
+    assert nr_seven[0].destination == nc_one.id
+    assert nr_seven[0].source == nc_four.id
+    assert nr_seven[0].type == "goes_to"
+    assert len(nc_four.get_related(new_model.type)) == 5
 
     new_relationships = new_relationship.get_all()
+
+
 
     nr_delete_three = new_relationship.relate(nc_one, nc_two)
     assert len(new_relationship.get_all()) == len(new_relationships) + 1
@@ -192,7 +198,7 @@ def test_models(dataset):
     nc_three.relate_to(p, new_relationship)
     new_relationship.relate(nc_four, p)
 
-    assert len(nc_four.get_related(new_model.type)) == 4
+    assert len(nc_four.get_related(new_model.type)) == 5
 
 def test_simple_model_properties(dataset):
 


### PR DESCRIPTION
…ces of a relationship so they do not appear blank

# Description

https://blackfynn.atlassian.net/browse/SHIELD-581

When using the function "relate_to" (in the ticket it was :
patient_record.relate_to(visit_record, relationship_type="attends") ), the relationship created did not link the two concepts (resulting in a blank source and destination in the relationship tab of the Models page of the dataset)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

I followed this script:

```
from blackfynn import Blackfynn
bf = Blackfynn("dev")
dset = bf.create_dataset("mytest")

patient = dset.create_model("patient", display_name="Patient")
visit = dset.create_model("visit", display_name="Visit")

age_prop = patient.add_property("age", data_type=int, title=True)
visitnum_prop = visit.add_property("number", data_type=int, title=True)

patient_record = patient.create_record({"age": 27})
visit_record = visit.create_record({"number": 0})

attends_relationship = patient_record.relate_to(visit_record, relationship_type="attends")
```

and verified that the models page of the dataset shows the source and destination of the "attends" relationship

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
