### PR TITLE
BaseNode.__eq__ type check first, also remove branching in logic

### DIFF
--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -247,10 +247,9 @@ class BaseNode(object):
         return item
 
     def __eq__(self, item):
-        if self.exists and item.exists:
-            return self.id == item.id
-        else:
-            return self is item
+        return ((isinstance(item, type(self)) or isinstance(self, type(item)))
+                and (self is item or
+                     (self.exists and item.exists and self.id == item.id)))
 
     @property
     def exists(self):


### PR DESCRIPTION
# Description

`BaseNode.__eq__` causes attribute errors when testing equality of python collections that contain BaseNode derived classes and other types that do not have an `exists` method. This PR fixes this behavior by testing the type of self and item before trying to call exists on item. It also improves the implementation of `__eq__` so that no branching behavior is invoked.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Ran pytest and also all of the sparcur pipelines.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works