### PR TITLE
#u2y7b inject response body api-related errors raised by the python client

### DIFF
--- a/blackfynn/base.py
+++ b/blackfynn/base.py
@@ -32,12 +32,11 @@ class BlackfynnRequest(object):
         self._logger = log.get_logger('blackfynn.base.BlackfynnRequest')
         
     def raise_for_status(self,resp):
-        max_text_length=500
         try:
             resp.raise_for_status()
         except HTTPError as e: #raise for status raise an HTTPError, so we can use it to grab the message
             if resp.text:
-                raise_from(HTTPError(resp.content,response=resp), e)
+                raise_from(HTTPError(resp.content, response=resp), e)
             else:
                 raise e
         return

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -183,3 +183,11 @@ def test_client_host_overrides():
 
     bf = Blackfynn(streaming_host=host)
     assert bf.settings.streaming_api_host == host
+
+
+def test_exception_raise():
+    bf = Blackfynn()
+    with pytest.raises(Exception) as excinfo:
+        bf._api._call('get','/datasets/plop')
+    assert "plop not found" in str(excinfo.value)
+    


### PR DESCRIPTION
# Description

`resp.raise_for_status()` does not inject the response body. We use this method when re-raising errors in the python client. Without the response body, the helpful information provided by the API is lost. 

## Github Issue

https://app.clickup.com/t/u2y7b

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual tests + adding test in test suite


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works