### PR TITLE
setup.py remove cython dependency, exclude tests*

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
+recursive-include tests *
+exclude .gitignore
+exclude .travis.yml
+exclude MANIFEST.in
 include requirements.txt
 include README.rst
 include INSTALL.rst

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,8 @@ setup(
     author_email = "mark@blackfynn.com",
     description = "Python client for the Blackfynn Platform",
     long_description = long_description,
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests*',)),
     package_dir={'blackfynn': 'blackfynn'},
-    setup_requires=['cython'],
     install_requires = reqs,
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4.0',
     entry_points = {


### PR DESCRIPTION
Some issues I encountered while writing an ebuild for this.
I don't know if these changes will break the usual CI build process, so let's find out!

## Description
Remove an apparently unneeded an unused cython dependency. 

Add tests to MANIFEST.in instead so that the test sources are available
for a call to setup.py test after a setup.py build sdist without having
setup.py try to install tests as a python module in site-packages which
is bad.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Changes required to get the package to build and install correctly on gentoo,
this PR is itself a test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works