### PR TITLE
Status log end point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ celerybeat-schedule
 
 # virtualenv
 venv/
+venv_test/
 ENV/
 
 # Spyder project settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Documentation at <https://developer.blackfynn.io/python/>
 
+## 3.3.0
+
+### Added
+- Function `status_log` for Dataset, returns the status change log of the dataset
+
 ## 3.2.0
 
 ### Added

--- a/blackfynn/__init__.py
+++ b/blackfynn/__init__.py
@@ -32,4 +32,4 @@ from .models import (
 )
 
 __title__ = "blackfynn"
-__version__ = "3.2.0"
+__version__ = "3.3.0"

--- a/blackfynn/api/data.py
+++ b/blackfynn/api/data.py
@@ -20,6 +20,8 @@ from blackfynn.models import (
     TabularSchema,
     TabularSchemaColumn,
     User,
+    StatusLogResponse,
+    StatusLogEntry,
     PublishInfo,
     UserCollaborator,
     TeamCollaborator,
@@ -55,6 +57,11 @@ class DatasetsAPI(APIBase):
         for key, value in resp.items():
             file_count += value
         return file_count
+
+    def status_log(self,ds,limit,offset):
+        id = self._get_id(ds)
+        resp = self._get( self._uri('/{id}/status-log?limit={limit}&offset={offset}', id=id, limit=limit, offset=offset))
+        return StatusLogResponse.from_dict(resp)
 
     def team_collaborators(self,ds):
         id = self._get_id(ds)

--- a/blackfynn/config.py
+++ b/blackfynn/config.py
@@ -297,7 +297,7 @@ class Settings(object):
         if name is None:
             return
         if name not in self.profiles:
-            raise Exception('Invaid profile name')
+            raise Exception('Invalid profile name')
         else:
             self.__dict__.update(self.profiles[name])
             self.active_profile = name

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -1902,7 +1902,7 @@ class Dataset(BaseCollection):
         kwargs.pop('type', None)
         super(Dataset, self).__init__(name, "DataSet", **kwargs)
         self.description = description or ''
-        self.status = status
+        self._status = status
         self.automatically_process_packages = automatically_process_packages
 
         # remove things that do not apply (a bit hacky)
@@ -1912,6 +1912,15 @@ class Dataset(BaseCollection):
     @as_native_str()
     def __repr__(self):
         return u"<Dataset name='{}' id='{}'>".format(self.name, self.id)
+
+    @property
+    def status(self):
+        """Get the current status."""
+        return self._status
+
+    @status.setter
+    def status(self, value):
+        raise AttributeError('Dataset.status is read-only.')
 
     def get_topology(self):
         """ Returns the set of Models and Relationships defined for the dataset
@@ -1929,6 +1938,9 @@ class Dataset(BaseCollection):
 
     def published(self):
         return self._api.datasets.published(self.id)
+
+    def status_log(self, limit = 25, offset = 0):
+        return self._api.datasets.status_log(self.id, limit, offset)
 
     def package_count(self):
         return self._api.datasets.package_count(self.id)
@@ -2119,7 +2131,7 @@ class Dataset(BaseCollection):
             name = self.name,
             description = self.description,
             automaticallyProcessPackages = self.automatically_process_packages,
-            properties = [p.as_dict() for p in self.properties]
+            properties = [p.as_dict() for p in self.properties],
         )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2166,6 +2178,103 @@ class PublishInfo(BaseNode):
     @as_native_str()
     def __repr__(self):
         return u"<PublishInfo status='{}' dataset_id='{}' version_count='{}' last_published='{}' doi='{}'>".format(self.status,  self.dataset_id, self.version_count, self.last_published, self.doi)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# UserStubDTO
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class UserStubDTO(BaseNode):
+
+    def __init__(self, node_id, first_name, last_name):
+        self.node_id = node_id
+        self.first_name = first_name
+        self.last_name = last_name
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            node_id = data.get('nodeId'),
+            first_name = data.get('firstName'),
+            last_name = data.get('lastName'),
+        )
+
+    @as_native_str()
+    def __repr__(self):
+        return u"<User node_id='{}' first_name='{}' last_name='{}' >".format(self.node_id,  self.first_name, self.last_name)
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# DatasetStatusStub
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class DatasetStatusStub(BaseNode):
+
+    def __init__(self, id, name, display_name):
+        self.id = id
+        self.name = name
+        self.display_name = display_name
+
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            id = data.get('id'),
+            name = data.get('name'),
+            display_name = data.get('displayName'),
+        )
+
+    @as_native_str()
+    def __repr__(self):
+        return u"<DatasetStatus id='{}' name='{}' display_name='{}'>".format(self.id, self.name, self.display_name)
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# StatusLogEntry
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class StatusLogEntry(BaseNode):
+
+    def __init__(self, user, status, updated_at):
+        self.user = user
+        self.status = status
+        self.updated_at = updated_at
+
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            user = UserStubDTO.from_dict(data.get('user')),
+            status = DatasetStatusStub.from_dict(data.get('status')),
+            updated_at = data.get('updatedAt'),
+        )
+
+    @as_native_str()
+    def __repr__(self):
+        return u"<StatusLogEntry user='{}' status='{}' updated_at='{}' >".format(self.user,  self.status, self.updated_at)
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# StatusLogResponse
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class StatusLogResponse(BaseNode):
+
+    def __init__(self, limit, offset, total_count, entries):
+        self.limit = limit
+        self.offset = offset
+
+        self.total_count = total_count
+        self.entries = entries
+
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            limit = data.get('limit'),
+            offset = data.get('offset'),
+            total_count = data.get('totalCount'),
+            entries = [StatusLogEntry.from_dict(e) for e in data.get('entries')]
+        )
+
+    @as_native_str()
+    def __repr__(self):
+        return u"<StatusLogResponse limit='{}' offset='{}' total_count='{}' entries='{}' >".format(self.limit,  self.offset, self.total_count, self.entries)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Collaborators

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -2242,7 +2242,7 @@ class StatusLogEntry(BaseNode):
         return cls(
             user = UserStubDTO.from_dict(data.get('user')),
             status = DatasetStatusStub.from_dict(data.get('status')),
-            updated_at = data.get('updatedAt'),
+            updated_at = datetime.datetime.strptime(data.get('updatedAt'), "%Y-%m-%dT%H:%M:%S.%fZ"),
         )
 
     @as_native_str()

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -12,6 +12,7 @@ import sys
 from uuid import uuid4
 
 import dateutil
+from dateutil.parser import parse
 import numpy as np
 import pandas as pd
 import pytz
@@ -2242,7 +2243,7 @@ class StatusLogEntry(BaseNode):
         return cls(
             user = UserStubDTO.from_dict(data.get('user')),
             status = DatasetStatusStub.from_dict(data.get('status')),
-            updated_at = datetime.datetime.strptime(data.get('updatedAt'), "%Y-%m-%dT%H:%M:%S.%fZ"),
+            updated_at = parse(data.get('updatedAt'))
         )
 
     @as_native_str()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ websocket-client>=0.50.0
 # CLI
 docopt>=0.6
 psutil>=5.4
+python-dateutil>=2.8.0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -42,17 +42,16 @@ def test_dataset_status_log(client, dataset):
     assert dataset_status_log.entries[0].user.node_id == client.profile.id
     assert dataset_status_log.entries[0].user.first_name == client.profile.first_name
     assert dataset_status_log.entries[0].user.last_name == client.profile.last_name
-    assert dataset_status_log.entries[0].updated_at == dataset.created_at
+    assert dataset_status_log.entries[0].updated_at == datetime.datetime.strptime(dataset.created_at, "%Y-%m-%dT%H:%M:%S.%fZ")
     assert dataset_status_log.entries[0].status.id == 1
     assert dataset_status_log.entries[0].status.name == 'NO_STATUS'
     assert dataset_status_log.entries[0].status.display_name == 'No Status'
 
 def test_status_is_readonly(client, dataset):
-    try:
+    with pytest.raises(AttributeError) as excinfo:
         dataset.status = 'New Thing'
         dataset.update()
-    except AttributeError as e:
-        assert str(e) == "Dataset.status is read-only."
+    assert "Dataset.status is read-only." in str(excinfo.value)
 
 def test_datasets(client, dataset):
     ds_items = len(dataset)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,6 +6,8 @@ import requests
 
 from blackfynn import Blackfynn
 from blackfynn.base import UnauthorizedException
+from dateutil.parser import parse
+
 # client library
 from blackfynn.models import BaseNode, DataPackage, Dataset, File, PublishInfo, UserCollaborator, TeamCollaborator
 
@@ -42,7 +44,7 @@ def test_dataset_status_log(client, dataset):
     assert dataset_status_log.entries[0].user.node_id == client.profile.id
     assert dataset_status_log.entries[0].user.first_name == client.profile.first_name
     assert dataset_status_log.entries[0].user.last_name == client.profile.last_name
-    assert dataset_status_log.entries[0].updated_at == datetime.datetime.strptime(dataset.created_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert dataset_status_log.entries[0].updated_at == parse(dataset.created_at)
     assert dataset_status_log.entries[0].status.id == 1
     assert dataset_status_log.entries[0].status.name == 'NO_STATUS'
     assert dataset_status_log.entries[0].status.display_name == 'No Status'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -33,6 +33,20 @@ def test_update_dataset(client, dataset, session_id):
     assert ds2.name == ds_name
     assert ds2.owner_id == client.profile.id
 
+def test_dataset_status_log(client, dataset):
+    dataset_status_log = dataset.status_log()
+    assert dataset_status_log.limit == 25
+    assert dataset_status_log.offset == 0
+    assert dataset_status_log.total_count == 1
+    assert len(dataset_status_log.entries) == 1
+    assert dataset_status_log.entries[0].user.node_id == client.profile.id
+    assert dataset_status_log.entries[0].user.first_name == client.profile.first_name
+    assert dataset_status_log.entries[0].user.last_name == client.profile.last_name
+    assert dataset_status_log.entries[0].updated_at == dataset.created_at
+    assert dataset_status_log.entries[0].status.id == 1
+    assert dataset_status_log.entries[0].status.name == 'NO_STATUS'
+    assert dataset_status_log.entries[0].status.display_name == 'No Status'
+
 def test_datasets(client, dataset):
     ds_items = len(dataset)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -47,6 +47,13 @@ def test_dataset_status_log(client, dataset):
     assert dataset_status_log.entries[0].status.name == 'NO_STATUS'
     assert dataset_status_log.entries[0].status.display_name == 'No Status'
 
+def test_status_is_readonly(client, dataset):
+    try:
+        dataset.status = 'New Thing'
+        dataset.update()
+    except AttributeError as e:
+        assert str(e) == "Dataset.status is read-only."
+
 def test_datasets(client, dataset):
     ds_items = len(dataset)
 


### PR DESCRIPTION
# Description

This PR exposes the new status-log endpoint as a function on the Dataset object.
limit and offset can be passed but are defaulted to 25 and 0 if nothing is passed.
This PR also locks the status of dataset as a read-only properties and raises an AttributeError if one attempts to change the status of a dataset


## ClickUp Issue

https://app.clickup.com/t/30cztr


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

The functionality is tested in the API itself. 
We do however have a test that checks that on creation of a dataset, we indeed create a dataset status and are able to retrieve it with all the correct info

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works