### PR TITLE
fixing test

### DIFF
--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -469,7 +469,7 @@ def test_related_records_pagination(dataset):
     # Get all records
     gotten = patient1.get_related()
     assert len(gotten) == 200
-    assert [r.get("field") for r in gotten] == list(map(str, range(200)))
+    assert [r.get("field") for r in gotten].sort() == list(map(str, range(200))).sort()
 
 def test_stringified_boolean_values(dataset):
     ppatient = dataset.create_model(


### PR DESCRIPTION
# Description

Now that model-service is fixed, the test_related_records_pagination is still failing because of the ordering of the response. By adding a `sort()` call, we fix the issue

## Github Issue

https://app.clickup.com/t/48chfp

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

