### PR TITLE
Tags setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Documentation at <https://developer.blackfynn.io/python/>
 
+## 3.4.0
+
+### Added
+- Support for Dataset.Tags
+
 ## 3.3.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Documentation at <https://developer.blackfynn.io/python/>
 ## 3.4.0
 
 ### Added
-- Support for Dataset.Tags
+- Support for `Dataset.tags`
 
 ## 3.3.1
 

--- a/blackfynn/__init__.py
+++ b/blackfynn/__init__.py
@@ -32,4 +32,4 @@ from .models import (
 )
 
 __title__ = "blackfynn"
-__version__ = "3.3.1"
+__version__ = "3.4.0"

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -1904,7 +1904,7 @@ class Dataset(BaseCollection):
         super(Dataset, self).__init__(name, "DataSet", **kwargs)
         self.description = description or ''
         self._status = status
-        self._tags = tags
+        self._tags = tags or []
         self.automatically_process_packages = automatically_process_packages
 
         # remove things that do not apply (a bit hacky)
@@ -1931,7 +1931,7 @@ class Dataset(BaseCollection):
 
     @tags.setter
     def tags(self, value):
-        if bool(value) and isinstance(value, list) and all(isinstance(elem, str) for elem in value):
+        if isinstance(value, list) and all(isinstance(elem, string_types) for elem in value):
             self._tags = value
         else:
             raise AttributeError('Dataset.tags should be a list of strings.')

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -1898,12 +1898,13 @@ class Organization(BaseNode):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 class Dataset(BaseCollection):
-    def __init__(self, name, description=None, status=None, automatically_process_packages=False, **kwargs):
+    def __init__(self, name, description=None, status=None, tags=None, automatically_process_packages=False, **kwargs):
         kwargs.pop('package_type', None)
         kwargs.pop('type', None)
         super(Dataset, self).__init__(name, "DataSet", **kwargs)
         self.description = description or ''
         self._status = status
+        self._tags = tags
         self.automatically_process_packages = automatically_process_packages
 
         # remove things that do not apply (a bit hacky)
@@ -1919,9 +1920,21 @@ class Dataset(BaseCollection):
         """Get the current status."""
         return self._status
 
+    @property
+    def tags(self):
+        """Get the current tags."""
+        return self._tags
+
     @status.setter
     def status(self, value):
         raise AttributeError('Dataset.status is read-only.')
+
+    @tags.setter
+    def tags(self, value):
+        if bool(value) and isinstance(value, list) and all(isinstance(elem, str) for elem in value):
+            self._tags = value
+        else:
+            raise AttributeError('Dataset.tags should be a list of strings.')
 
     def get_topology(self):
         """ Returns the set of Models and Relationships defined for the dataset
@@ -2133,6 +2146,7 @@ class Dataset(BaseCollection):
             description = self.description,
             automaticallyProcessPackages = self.automatically_process_packages,
             properties = [p.as_dict() for p in self.properties],
+            tags = self.tags
         )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -55,6 +55,17 @@ def test_status_is_readonly(client, dataset):
         dataset.update()
     assert "Dataset.status is read-only." in str(excinfo.value)
 
+def test_tags_is_list_of_strings_only(client, dataset):
+    with pytest.raises(AttributeError) as excinfo:
+        dataset.tags = 'New Thing'
+    assert "Dataset.tags should be a list of strings." in str(excinfo.value)
+    with pytest.raises(AttributeError) as excinfo:
+        dataset.tags = [1,2,3]
+    assert "Dataset.tags should be a list of strings." in str(excinfo.value)
+    dataset.tags = ["a","b","c"]
+    dataset.update()
+    assert dataset.tags == ["a","b","c"]
+    
 def test_datasets(client, dataset):
     ds_items = len(dataset)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -64,7 +64,8 @@ def test_tags_is_list_of_strings_only(client, dataset):
     assert "Dataset.tags should be a list of strings." in str(excinfo.value)
     dataset.tags = ["a","b","c"]
     dataset.update()
-    assert dataset.tags == ["a","b","c"]
+    dataset_from_platform = client.get_dataset(dataset.id)
+    assert dataset_from_platform.tags == ["a","b","c"]
     
 def test_datasets(client, dataset):
     ds_items = len(dataset)


### PR DESCRIPTION
# Description

In order to facilitate adding tags to SPARC datasets via a python script, we need to have the ability to edit the `tags` field of a Dataset. This PR add a setter on tags that checks that only a list of string can be passed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Tests were added to make sure we reject strings and array of integers but accept an array of strings

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works