### PR TITLE
agent wrap websocket import to allow failure

### DIFF
--- a/blackfynn/api/agent.py
+++ b/blackfynn/api/agent.py
@@ -11,15 +11,16 @@ from time import sleep
 
 import semver
 from future.utils import raise_from
-try:
-    from websocket import create_connection
-except ModuleNotFoundError:
-    pass
-
 from blackfynn.log import get_logger
 from blackfynn.models import Collection, Dataset, DataPackage
 
 logger = get_logger('blackfynn.agent')
+
+try:
+    from websocket import create_connection
+except ModuleNotFoundError:
+    logger.warn("websocket-client is not installed - uploading with the Agent will not work")
+
 
 MINIMUM_AGENT_VERSION = semver.parse_version_info("0.2.2")
 DEFAULT_LISTEN_PORT = 11235

--- a/blackfynn/api/agent.py
+++ b/blackfynn/api/agent.py
@@ -11,7 +11,10 @@ from time import sleep
 
 import semver
 from future.utils import raise_from
-from websocket import create_connection
+try:
+    from websocket import create_connection
+except ModuleNotFoundError:
+    pass
 
 from blackfynn.log import get_logger
 from blackfynn.models import Collection, Dataset, DataPackage


### PR DESCRIPTION
# Description

The websocket dependency is not required unless you are actually using
the agent. This pull request makes the import optional so that the websocket
dependency is not a hard failure if it is missing. Anyone installing via pip should
never encounter this issue since websocket-client is listed in the requirements.

## Github Issue

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Change has been used in production sparc curation code for a couple of months.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works