### PR TITLE
Add api to package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Documentation at <https://developer.blackfynn.io/python/>
 
+## 3.6.1
+
+### Fixed
+- Changed construction of Package returned by `get_package_by_filename` to include the session.
+
 ## 3.6.0
 
 ### Added

--- a/blackfynn/__init__.py
+++ b/blackfynn/__init__.py
@@ -32,4 +32,4 @@ from .models import (
 )
 
 __title__ = "blackfynn"
-__version__ = "3.6.0"
+__version__ = "3.6.1"

--- a/blackfynn/api/data.py
+++ b/blackfynn/api/data.py
@@ -77,7 +77,7 @@ class DatasetsAPI(APIBase):
     def get_packages_by_filename(self,ds,filename):
         id = self._get_id(ds)
         resp = self._get( self._uri('/{id}/packages?filename={filename}', id=id, filename=filename))
-        return [DataPackage.from_dict(p) for p in resp.get('packages')]
+        return [DataPackage.from_dict(p, api=self.session) for p in resp.get('packages')]
 
     def owner(self, ds):
         return next(iter(filter(lambda x: x.role == 'owner', self.user_collaborators(ds))))

--- a/blackfynn/models.py
+++ b/blackfynn/models.py
@@ -853,8 +853,8 @@ class DataPackage(BaseDataNode):
 
     @classmethod
     def from_dict(cls, data, *args, **kwargs):
+        data['content']['id'] = data['content']['nodeId']
         item = super(DataPackage, cls).from_dict(data, *args, **kwargs)
-
         # parse objects
         objects = data.get('objects', None)
         if objects is not None:
@@ -863,7 +863,6 @@ class DataPackage(BaseDataNode):
                     continue
                 odata = data['objects'][otype]
                 item.__dict__[otype] = [File.from_dict(x) for x in odata]
-
         return item
 
     @classmethod

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -49,10 +49,12 @@ def test_get_by_filename(dataset, upload_args, n_files):
             break
         else:
             time.sleep(0.5)
-    p = dataset.get_packages_by_filename('test-78f3ea50-b')
-    assert(len(p) == 1)
-    assert(p[0].name == 'test-78f3ea50-b')
-
+    packages = dataset.get_packages_by_filename('test-78f3ea50-b')
+    assert(len(packages) == 1)
+    assert(packages[0].name == 'test-78f3ea50-b')
+    files = packages[0].files
+    assert len(files) == 1
+    assert(files[0].name == 'test-78f3ea50-b')
 
 @pytest.mark.parametrize('upload_args,n_files', [
     ([FILE1], 1),               # Single file


### PR DESCRIPTION
# Description

When construction the `Package` objects in the `get_package_by_filename` function, I omitted to pass the session. Currently, these objects do not have access to any api functionality. This PR fixes the issue

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works
