### PR TITLE
fixing ordering in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install --upgrade -r requirements-test.txt
 
 
-script: pytest
+script: pytest -s
 after_success: bash <(curl -s https://codecov.io/bash)
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install --upgrade -r requirements-test.txt
 
 
-script: pytest -s
+script: pytest
 after_success: bash <(curl -s https://codecov.io/bash)
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 env:
   global:
-    - AGENT_VERSION="0.2.6"
+    - AGENT_VERSION="0.2.7"
 
 install:
   # Install Blackfynn CLI agent

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -469,7 +469,7 @@ def test_related_records_pagination(dataset):
     # Get all records
     gotten = fred.get_related()
     assert len(gotten) == 200
-    assert sorted([int(r.get("field")) for r in gotten]) == list(range(200))
+    assert [int(r.get("field")) for r in gotten] == list(range(200))
 
 def test_stringified_boolean_values(dataset):
     ppatient = dataset.create_model(

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -469,7 +469,7 @@ def test_related_records_pagination(dataset):
     # Get all records
     gotten = fred.get_related()
     assert len(gotten) == 200
-    assert [int(r.get("field")) for r in gotten] == list(range(200))
+    assert sorted([int(r.get("field")) for r in gotten]) == list(range(200))
 
 def test_stringified_boolean_values(dataset):
     ppatient = dataset.create_model(


### PR DESCRIPTION
# Description

Looks like the same test that was fixed is now failing. Since it looks like we can not rely on the query to always sort the objects in the response consistently, I propose to sort the results before comparison.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

